### PR TITLE
Add changes from notebook to `swag.py`

### DIFF
--- a/augmentations.py
+++ b/augmentations.py
@@ -1,8 +1,8 @@
 import numpy as np
 import copy
 
-class ChangeChannels:
 
+class ChangeChannels:
     """
     Copies the data while changing the data type to the provided one
 
@@ -20,11 +20,14 @@ class ChangeChannels:
     def __call__(self, state_dict):
         x, metadata = state_dict[self.key]
 
-        x = np.expand_dims(x[self.channel_to_keep,:], axis=0)
+        x = np.expand_dims(x[self.channel_to_keep, :], axis=0)
         state_dict[self.key] = (x, metadata)
 
     def __str__(self):
-        return f"ChangeChannels (channel_to_keep={self.channel_to_keep}, key={self.key})"
+        return (
+            f"ChangeChannels (channel_to_keep={self.channel_to_keep}, key={self.key})"
+        )
+
 
 class DuplicateEvent:
     """

--- a/swag.py
+++ b/swag.py
@@ -17,7 +17,7 @@ from seisbench.models import EQTransformer
 import swag
 from swag.posteriors import SWAG
 
-from utils import train_epoch, test_loop, predict, preprocess
+from utils import train_epoch, test_loop, predict, preprocess, make_loss_fn
 
 
 # Argument Parsing
@@ -260,6 +260,9 @@ if args.loss == "CE":
 else:
     print("Error! Only Cross Entropy Loss (--loss=CE) supported at the moment.")
     sys.exit(2)
+
+loss_fn = make_loss_fn(loss_fn)
+
 
 start_epoch = 0
 if args.resume is not None:

--- a/swag.py
+++ b/swag.py
@@ -226,7 +226,7 @@ if args.swa:
         model_cfg,
         no_cov_mat=args.no_cov_mat,
         max_num_models=args.max_num_models,
-        in_channels= 1
+        in_channels=1,
     )
     swag_model.to(args.device)
     swa_n = 0

--- a/swag.py
+++ b/swag.py
@@ -167,6 +167,8 @@ parser.add_argument(
 
 parser.add_argument("--seed", type=int, default=42, help="random seed (default: 42)")
 
+parses.add_argument("--num_workers", type=int, default=0, help"Number of Workers (default: 0)")
+
 parser.add_argument(
     "--no_schedule",
     action="store_true",
@@ -207,7 +209,7 @@ print(f"Loading dataset {args.dataset} from {args.dataset_path}")
 data = WaveformDataset(args.dataset_path)
 
 print("Preprocessing data")
-train_loader, dev_loader, _ = preprocess(data, args.batch_size)
+train_loader, dev_loader, _ = preprocess(data, args.batch_size, args.num_workers)
 
 print("Preparing model")
 # TODO: Pass arguments to EQTransformer

--- a/swag.py
+++ b/swag.py
@@ -167,7 +167,7 @@ parser.add_argument(
 
 parser.add_argument("--seed", type=int, default=42, help="random seed (default: 42)")
 
-parses.add_argument("--num_workers", type=int, default=0, help"Number of Workers (default: 0)")
+parses.add_argument("--num_workers", type=int, default=0, help="Number of Workers (default: 0)")
 
 parser.add_argument(
     "--no_schedule",

--- a/swag.py
+++ b/swag.py
@@ -337,7 +337,7 @@ for epoch in range(start_epoch, args.epochs):
         or epoch % args.eval_freq == args.eval_freq - 1
         or epoch == args.epochs - 1
     ):
-        test_res = test_loop(model, dev_loader, loss_fn, verbose=args.verbose)
+        test_res = test_loop(model, dev_loader, loss_fn)
     else:
         # Make sure test_res is defined properly
         test_res = {"loss": None, "accuracy": None}

--- a/swag.py
+++ b/swag.py
@@ -172,6 +172,10 @@ parser.add_argument(
 )
 
 parser.add_argument(
+    "--verbose", action="store_true", help="Verbose training)"
+)
+
+parser.add_argument(
     "--no_schedule",
     action="store_true",
     help="store schedule",
@@ -325,7 +329,7 @@ for epoch in range(start_epoch, args.epochs):
     else:
         lr = args.lr_init
 
-    train_res = train_epoch(model, train_loader, loss_fn, optimizer)
+    train_res = train_epoch(model, train_loader, loss_fn, optimizer, verbose=args.verbose)
     # Evaluate dev set on first epoch, on eval_freq, and on final epoch
     # TODO: What does eval_freq exactly mean
     if (
@@ -333,7 +337,7 @@ for epoch in range(start_epoch, args.epochs):
         or epoch % args.eval_freq == args.eval_freq - 1
         or epoch == args.epochs - 1
     ):
-        test_res = test_loop(model, dev_loader, loss_fn)
+        test_res = test_loop(model, dev_loader, loss_fn, verbose=args.verbose)
     else:
         # Make sure test_res is defined properly
         test_res = {"loss": None, "accuracy": None}

--- a/swag.py
+++ b/swag.py
@@ -264,9 +264,9 @@ optimizer = torch.optim.SGD(
 
 # TODO: Respect passed argument
 if args.loss == "CE":
-    loss_fn = F.cross_entropy
+    loss_fn = F.binary_cross_entropy
 else:
-    print("Error! Only Cross Entropy Loss (--loss=CE) supported at the moment.")
+    print("Error! Only Binary Cross Entropy Loss (--loss=CE) supported at the moment.")
     sys.exit(2)
 
 loss_fn = make_loss_fn(loss_fn)

--- a/swag.py
+++ b/swag.py
@@ -167,7 +167,9 @@ parser.add_argument(
 
 parser.add_argument("--seed", type=int, default=42, help="random seed (default: 42)")
 
-parses.add_argument("--num_workers", type=int, default=0, help="Number of Workers (default: 0)")
+parser.add_argument(
+    "--num_workers", type=int, default=0, help="Number of Workers (default: 0)"
+)
 
 parser.add_argument(
     "--no_schedule",

--- a/utils.py
+++ b/utils.py
@@ -88,6 +88,7 @@ def predict(model, dataloader):
 
     return {"predictions": np.vstack(predictions), "targets": np.concatenate(targets)}
 
+
 def preprocess(data, batch_size):
     """Takes in a WaveformDataset and performs preprocessing on it.  Returns"""
     train, dev, test = data.train_dev_test()
@@ -100,9 +101,15 @@ def preprocess(data, batch_size):
 
     # TODO: Proper data preprocessing
     augmentations = [
-        sbg.WindowAroundSample(list(phase_dict.keys()), samples_before=3000, windowlen=6000, selection="random", strategy="variable"),
+        sbg.WindowAroundSample(
+            list(phase_dict.keys()),
+            samples_before=3000,
+            windowlen=6000,
+            selection="random",
+            strategy="variable",
+        ),
         sbg.RandomWindow(windowlen=6000, strategy="pad"),
-        sbg.RandomArrayRotation(keys='X', axis=-1),
+        sbg.RandomArrayRotation(keys="X", axis=-1),
         sbg.ChangeDtype(np.float32),
         ChangeChannels(0),
         sbg.ProbabilisticLabeller(label_columns=phase_dict, sigma=1e-9, dim=0),

--- a/utils.py
+++ b/utils.py
@@ -66,7 +66,7 @@ def test_loop(model, dataloader, loss_fn):
 
             # HACK: See above.
             if isinstance(model, SWAG):
-                test_loss += loss_fn(pred, batch["y"]., batch["detections"]).item()
+                test_loss += loss_fn(pred, batch["y"], batch["detections"]).item()
             else:
                 test_loss += loss_fn(pred, batch["y"].to(model.device), batch["detections"].to(model.device)).item()
 

--- a/utils.py
+++ b/utils.py
@@ -28,7 +28,7 @@ def train_epoch(model, dataloader, loss_fn, optimizer, verbose=False):
         pred = model(batch["X"].to(model.device))
 
         loss = loss_fn(
-            pred, batch["y"].to(model.device), batch["detection"].to(model.device)
+            pred, batch["y"].to(model.device), batch["detections"].to(model.device)
         )
 
         # Backpropagation
@@ -89,9 +89,10 @@ def predict(model, dataloader):
 
     with torch.no_grad():
         for batch in dataloader:
-            pred = model(batch["X"].to(model.device))
+            # TODO: Fix dimensions here.
+            det_pred, p_pred, s_pred = model(batch["X"].to(model.device))
 
-            predictions.append(F.softmax(pred, dim=1).cpu().numpy())
+            predictions.append(torch.stack((p_pred, s_pred), dim=1).numpy())
             targets.append(batch["y"].numpy())
 
     return {"predictions": np.vstack(predictions), "targets": np.concatenate(targets)}

--- a/utils.py
+++ b/utils.py
@@ -10,7 +10,7 @@ from seisbench.util import worker_seeding
 from swag.posteriors import SWAG
 import seisbench.generate as sbg
 from torch.utils.data import DataLoader
-from augmentations import ChangeChannels
+from augmentations import ChangeChannels, DuplicateEvent
 
 """Separate file for keeping some functions.  Arguably, these could just live in main.py, but this way they should be directly usable in a jupyter notebook via `import utils`."""
 
@@ -89,35 +89,143 @@ def predict(model, dataloader):
     return {"predictions": np.vstack(predictions), "targets": np.concatenate(targets)}
 
 
-def preprocess(data, batch_size):
-    """Takes in a WaveformDataset and performs preprocessing on it.  Returns"""
+def split_and_apply_generators(data):
     train, dev, test = data.train_dev_test()
+    return {
+        "train_generator": sbg.GenericGenerator(train),
+        "dev_generator": sbg.GenericGenerator(dev),
+        "test_generator": sbg.GenericGenerator(test),
+    }
 
-    phase_dict = {"trace_p_arrival_sample": "P", "trace_s_arrival_sample": "S"}
 
-    train_generator = sbg.GenericGenerator(train)
-    dev_generator = sbg.GenericGenerator(dev)
-    test_generator = sbg.GenericGenerator(test)
+def preprocess(data, batch_size, num_workers):
+    """Takes in a WaveformDataset and performs preprocessing on it.  Returns"""
+    ################################################################################
+    # Configure augmentations; basically: https://github.com/seisbench/pick-benchmark/blob/74ba1965b1dd5e770a8358ed83e339a01460e86b/benchmark/models.py#L440
+    ################################################################################
 
-    # TODO: Proper data preprocessing
-    augmentations = [
-        sbg.WindowAroundSample(
-            list(phase_dict.keys()),
-            samples_before=3000,
-            windowlen=6000,
-            selection="random",
-            strategy="variable",
-        ),
-        sbg.RandomWindow(windowlen=6000, strategy="pad"),
-        sbg.RandomArrayRotation(keys="X", axis=-1),
-        sbg.ChangeDtype(np.float32),
-        ChangeChannels(0),
-        sbg.ProbabilisticLabeller(label_columns=phase_dict, sigma=1e-9, dim=0),
-    ]
+    phase_dict = {
+        "trace_p_arrival_sample": "P",
+        "trace_pP_arrival_sample": "P",
+        "trace_P_arrival_sample": "P",
+        "trace_P1_arrival_sample": "P",
+        "trace_Pg_arrival_sample": "P",
+        "trace_Pn_arrival_sample": "P",
+        "trace_PmP_arrival_sample": "P",
+        "trace_pwP_arrival_sample": "P",
+        "trace_pwPm_arrival_sample": "P",
+        "trace_s_arrival_sample": "S",
+        "trace_S_arrival_sample": "S",
+        "trace_S1_arrival_sample": "S",
+        "trace_Sg_arrival_sample": "S",
+        "trace_SmS_arrival_sample": "S",
+        "trace_Sn_arrival_sample": "S",
+    }
 
-    train_generator.add_augmentations(augmentations)
-    dev_generator.add_augmentations(augmentations)
-    test_generator.add_augmentations(augmentations)
+    def get_joint_augmentations(sample_boundaries, sigma):
+        p_phases = [key for key, val in phase_dict.items() if val == "P"]
+        s_phases = [key for key, val in phase_dict.items() if val == "S"]
+
+        detection_labeller = sbg.DetectionLabeller(
+            p_phases, s_phases=s_phases, key=("X", "detections")
+        )
+
+        block1 = [
+            # In 2/3 of the cases, select windows around picks, to reduce amount of noise traces in training.
+            # Uses strategy variable, as padding will be handled by the random window.
+            # In 1/3 of the cases, just returns the original trace, to keep diversity high.
+            sbg.OneOf(
+                [
+                    sbg.WindowAroundSample(
+                        list(phase_dict.keys()),
+                        samples_before=6000,
+                        windowlen=12000,
+                        selection="random",
+                        strategy="variable",
+                    ),
+                    sbg.NullAugmentation(),
+                ],
+                probabilities=[2, 1],
+            ),
+            sbg.RandomWindow(
+                low=sample_boundaries[0],
+                high=sample_boundaries[1],
+                windowlen=6000,
+                strategy="pad",
+            ),
+            sbg.ProbabilisticLabeller(label_columns=phase_dict, sigma=sigma, dim=0),
+            detection_labeller,
+            # Normalize to ensure correct augmentation behavior
+            sbg.Normalize(detrend_axis=-1, amp_norm_axis=-1, amp_norm_type="peak"),
+        ]
+
+        block2 = [
+            sbg.ChangeDtype(np.float32, "X"),
+            sbg.ChangeDtype(np.float32, "y"),
+            sbg.ChangeDtype(np.float32, "detections"),
+            ChangeChannels(0),
+        ]
+
+        return block1, block2
+
+    def get_train_augmentations(rotate_array=False):
+        if rotate_array:
+            rotation_block = [
+                sbg.OneOf(
+                    [
+                        sbg.RandomArrayRotation(["X", "y", "detections"]),
+                        sbg.NullAugmentation(),
+                    ],
+                    [0.99, 0.01],
+                )
+            ]
+        else:
+            rotation_block = []
+
+        augmentation_block = [
+            # Add secondary event
+            sbg.OneOf(
+                [DuplicateEvent(label_keys="y"), sbg.NullAugmentation()],
+                probabilities=[0.3, 0.7],
+            ),
+            # Gaussian noise
+            sbg.OneOf([sbg.GaussianNoise(), sbg.NullAugmentation()], [0.5, 0.5]),
+            # Array rotation
+            *rotation_block,
+            # Gaps
+            sbg.OneOf([sbg.AddGap(), sbg.NullAugmentation()], [0.2, 0.8]),
+            # Channel dropout
+            sbg.OneOf([sbg.ChannelDropout(), sbg.NullAugmentation()], [0.3, 0.7]),
+            # Augmentations make second normalize necessary
+            sbg.Normalize(detrend_axis=-1, amp_norm_axis=-1, amp_norm_type="peak"),
+        ]
+
+        block1, block2 = get_joint_augmentations(
+            sample_boundaries=(None, None), sigma=20
+        )
+
+        return block1 + augmentation_block + block2
+
+    def get_val_augmentations():
+        block1, block2 = get_joint_augmentations(
+            sample_boundaries=(None, None), sigma=20
+        )
+
+        return block1 + block2
+
+    ################################################################################
+    # Apply augmentations
+    ################################################################################
+
+    res = split_and_apply_generators(data)
+
+    train_generator = res["train_generator"]
+    dev_generator = res["dev_generator"]
+    test_generator = res["test_generator"]
+
+    train_generator.add_augmentations(get_train_augmentations(rotate_array=True))
+    dev_generator.add_augmentations(get_val_augmentations())
+    test_generator.add_augmentations(get_val_augmentations())
 
     # picks = {}
     # for i in range(0, 6000, 100):
@@ -129,10 +237,6 @@ def preprocess(data, batch_size):
 
     # plt.bar(picks.keys(), picks.values())
     # plt.show()
-
-    # NOTE: Hard-coded num_workers
-    # FIXME: Value > 0 gives scray multi-processing error
-    num_workers = 0
 
     train_loader = DataLoader(
         train_generator,


### PR DESCRIPTION
I added (using my incredible copy-paste skills) the stuff from the training notebook into the script.

In `seisbench`, I reverted the changes to the output format from EQTransformer, and those changes are now also reflected whenever a model is used (`train_epoch`, `test_loop`) *except* for `predict` right now.

Also, `loss_fn` is now adapted to work with the tuple output from EQTransformer and calculates the vector-cross-entropy loss like in the training notebook.